### PR TITLE
bug fix in logsout2struct

### DIFF
--- a/templates/PID_example/main_PID.m
+++ b/templates/PID_example/main_PID.m
@@ -84,16 +84,16 @@ simout = logsout2struct(out);
 h = tiledlayout(3,1,'TileSpacing','compact','Padding','compact');
 
 h1 = nexttile;
-plot(h1,simout.time,simout.yMeas,simout.time,simout.r);
+plot(h1,simout.yMeas.Time,simout.yMeas.Values,simout.r.Time,simout.r.Values);
 legend(h1,'system output','reference')
 
 h2 = nexttile;
 
-plot(h2,simout.time,simout.e);
+plot(h2,simout.e.Time,simout.e.Values);
 legend(h2,'erreur')
 
 h3 = nexttile;
-plot(out.logsout.getElement('controlCmd').Values.controlCmd,'Parent',h3,'LineWidth',2);
+plot(simout.controlCmd.Time,simout.controlCmd.Values);
 legend(h3,'controller command');
 
 h.XLabel.String = 't (s)';

--- a/tools/logsout2struct.m
+++ b/tools/logsout2struct.m
@@ -21,8 +21,6 @@ arguments
     out Simulink.SimulationOutput
 end
 
-structout.time = out.tout;
-
 %% loop over yout
 try out.yout.numElements
     for ii = 1:out.yout.numElements
@@ -35,12 +33,12 @@ try out.yout.numElements
         field_nms = fieldnames(structout_yout); %grab names of signals
         
         % write each signal as a new leaf in the struct
-        for kk = 1:length(field_nms)
-            if ~isa(structout_yout.(field_nms{kk}),'struct')
-                structout.(field_nms{kk}) = structout_yout.(field_nms{kk});
-
-            else
+        for kk = 1:length(field_nms)               
+            try
                 structout.(field_nms{kk}) = structout_yout.(field_nms{kk}).(field_nms{kk});
+
+            catch
+                structout.(field_nms{kk}) = structout_yout.(field_nms{kk});
 
             end
         end
@@ -64,19 +62,19 @@ try out.logsout.numElements
 
         for kk = 1:length(field_nms)
 
-            if ~isa(structout_logsout.(field_nms{kk}),'struct')
-                structout.(field_nms{kk}) = structout_logsout.(field_nms{kk});
-
-            else
+            try
                 structout.(field_nms{kk}) = structout_logsout.(field_nms{kk}).(field_nms{kk});
+
+            catch ME
+                structout.(field_nms{kk}) = structout_logsout.(field_nms{kk});
 
             end
 
         end
     end
 
-catch 
-    warning('no logsout found in SimulationOutput, continuing');
+catch ME
+    warning('Error detected in logsout %s. Skipping signal, continuing writing logsout. The original error was %s',myElem.Name,ME.message);
 
 end
 
@@ -93,7 +91,8 @@ if any(name=='<')
     name = strrep(strrep(ts.Name, '<' , ''), '>' , '');
 
 end
-structout.(name) = ts.Data;
+structout.(name).Time = ts.Time;
+structout.(name).Values = ts.Data;
 
 end
 


### PR DESCRIPTION
Simulations with non-constant sample rates write logs with different time bases. Structout now stores the time base of each leaf explicitly. I feel that is better than interpolating to a common base.